### PR TITLE
Pass the key set validator as Rocket state

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,5 +1,10 @@
 # server
 
+## TODO list
+
+- Make the validator part of Rocket managed state
+- Validate the issuer of the token
+
 ## Developing locally
 
 ```bash

--- a/server/README.md
+++ b/server/README.md
@@ -1,10 +1,5 @@
 # server
 
-## TODO list
-
-- Make the validator part of Rocket managed state
-- Validate the issuer of the token
-
 ## Developing locally
 
 ```bash

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,18 +2,21 @@
 extern crate rocket;
 
 use rocket::routes;
+use rocket_contrib::json::Json;
 
 mod location;
 mod openid;
 mod user;
 
 use location::{Coordinate, Location};
-use rocket_contrib::json::Json;
+use openid::{authority::Authority, validator::Validator};
 use user::User;
 
 #[launch]
 async fn rocket() -> rocket::Rocket {
-    rocket::ignite().mount("/", routes![get_a_location])
+    rocket::ignite()
+        .manage(Validator::new(Authority::MSA))
+        .mount("/", routes![get_a_location])
 }
 
 #[post("/hello")]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -9,13 +9,13 @@ mod openid;
 mod user;
 
 use location::{Coordinate, Location};
-use openid::{authority::Authority, validator::Validator};
+use openid::validator::Validator;
 use user::User;
 
 #[launch]
 async fn rocket() -> rocket::Rocket {
     rocket::ignite()
-        .manage(Validator::new(Authority::MSA))
+        .manage(Validator::new_msa())
         .mount("/", routes![get_a_location])
 }
 

--- a/server/src/openid/key_set.rs
+++ b/server/src/openid/key_set.rs
@@ -8,7 +8,7 @@ use crate::openid::authority::{Authority, Claims};
 pub trait KeySetFetcher {
     type Error;
 
-    async fn fetch<C: Claims>(&mut self, authority: &Authority<C>) -> Result<KeySet, Self::Error>;
+    async fn fetch<C: Claims>(&self, authority: &Authority<C>) -> Result<KeySet, Self::Error>;
 }
 
 pub struct NetworkKeySetFetcher {}
@@ -23,7 +23,7 @@ impl NetworkKeySetFetcher {
 impl KeySetFetcher for NetworkKeySetFetcher {
     type Error = reqwest::Error;
 
-    async fn fetch<C: Claims>(&mut self, authority: &Authority<C>) -> Result<KeySet, Self::Error> {
+    async fn fetch<C: Claims>(&self, authority: &Authority<C>) -> Result<KeySet, Self::Error> {
         // Need the `.compat()` wrappers around futures from `reqwest`, since
         // it uses Tokio 0.2 and we will be running on Tokio 0.3.
 

--- a/server/src/openid/validator.rs
+++ b/server/src/openid/validator.rs
@@ -11,7 +11,7 @@ use crate::openid::{
 pub type MSAValidator = Validator<MSAClaims, NetworkKeySetFetcher>;
 
 impl MSAValidator {
-    fn new_msa() -> Self {
+    pub fn new_msa() -> MSAValidator {
         Validator::new(Authority::MSA)
     }
 }

--- a/server/src/openid/validator.rs
+++ b/server/src/openid/validator.rs
@@ -2,8 +2,18 @@ use std::time::{Duration, Instant};
 
 use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
 
-use crate::openid::authority::{Authority, Claims};
-use crate::openid::key_set::{Key, KeySet, KeySetFetcher, NetworkKeySetFetcher};
+use crate::openid::{
+    authority::{Authority, Claims, MSAClaims},
+    key_set::{Key, KeySet, KeySetFetcher, NetworkKeySetFetcher},
+};
+
+pub type MSAValidator = Validator<MSAClaims, NetworkKeySetFetcher>;
+
+impl MSAValidator {
+    fn new_msa() -> Self {
+        Validator::new(Authority::MSA)
+    }
+}
 
 pub struct Validator<C: Claims, F: KeySetFetcher> {
     /// The OpenID authority to use to validate.

--- a/server/src/user.rs
+++ b/server/src/user.rs
@@ -27,7 +27,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for User {
     async fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
         match request.headers().get_one("Authorization") {
             Some(auth_header) => {
-                let mut validator_state = try_outcome!(request
+                let validator_state = try_outcome!(request
                     .guard::<State<MSAValidator>>()
                     .await
                     .map_failure(|_| {

--- a/server/src/user.rs
+++ b/server/src/user.rs
@@ -1,9 +1,14 @@
-use rocket::async_trait;
-use rocket::http::Status;
-use rocket::request::{FromRequest, Outcome, Request};
+use rocket::{
+    async_trait,
+    http::Status,
+    request::{FromRequest, Outcome, Request},
+    State,
+};
 
-use crate::openid::authority::{Authority, Claims};
-use crate::openid::validator::Validator;
+use crate::openid::{
+    authority::{Authority, Claims, MSAClaims},
+    validator::MSAValidator,
+};
 
 pub struct User {
     id: String,
@@ -22,9 +27,17 @@ impl<'a, 'r> FromRequest<'a, 'r> for User {
     async fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
         match request.headers().get_one("Authorization") {
             Some(auth_header) => {
-                let mut validator = Validator::new(Authority::MSA);
+                let mut validator_state = try_outcome!(request
+                    .guard::<State<MSAValidator>>()
+                    .await
+                    .map_failure(|_| {
+                        (
+                            Status::InternalServerError,
+                            AuthError::FailedToGetTokenValidator,
+                        )
+                    }));
 
-                if let Some(token_claims) = validator.validate(auth_header).await {
+                if let Some(token_claims) = validator_state.validate(auth_header).await {
                     Outcome::Success(Self {
                         id: token_claims.user_id(),
                     })
@@ -39,6 +52,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for User {
 
 #[derive(Debug)]
 pub enum AuthError {
+    FailedToGetTokenValidator,
     MissingAuthHeader,
     InvalidToken,
 }

--- a/server/src/user.rs
+++ b/server/src/user.rs
@@ -5,10 +5,7 @@ use rocket::{
     State,
 };
 
-use crate::openid::{
-    authority::{Authority, Claims, MSAClaims},
-    validator::MSAValidator,
-};
+use crate::openid::{authority::Claims, validator::MSAValidator};
 
 pub struct User {
     id: String,


### PR DESCRIPTION
Since key sets are currently cached in-memory by a `Validator`, we want to use the same `Validator` to validate each request. These changes make use of Rocket's `State` (https://rocket.rs/v0.4/guide/state/#within-guards) to keep a single, managed instance of a `Validator` alive for re-use.

Confirmed:
- No warnings.
- Tests pass.
- (Via `println!` and Postman) Only one request is made to fetch keys (on first validation) for this branch, whereas on `main` a request is made for each validation.